### PR TITLE
Use configured TTL on keepAlive

### DIFF
--- a/src/main/java/com/dekses/cassandra/lock/CassandraLock.java
+++ b/src/main/java/com/dekses/cassandra/lock/CassandraLock.java
@@ -95,7 +95,7 @@ public class CassandraLock implements Lock {
 	 * Throws exception if query not applied, it means lock lease was lost.
 	 */
 	public void keepAlive() throws LockLeaseLostException {
-		ResultSet rs = session.execute(updatePrep.bind(owner, name, owner));
+		ResultSet rs = session.execute(updatePrep.bind(ttl, owner, name, owner));
 		if (!rs.wasApplied()) {
 			throw new LockLeaseLostException();
 		}

--- a/src/main/java/com/dekses/cassandra/lock/LockFactory.java
+++ b/src/main/java/com/dekses/cassandra/lock/LockFactory.java
@@ -67,9 +67,9 @@ public class LockFactory {
 		insertPrep.setConsistencyLevel(ConsistencyLevel.QUORUM);
 		selectPrep = session.prepare("SELECT * FROM lock_leases WHERE name = ?");
 		selectPrep.setConsistencyLevel(ConsistencyLevel.SERIAL);
-		deletePrep = session.prepare("DELETE FROM lock_leases where name = ? IF owner = ?");
+		deletePrep = session.prepare("DELETE FROM lock_leases WHERE name = ? IF owner = ?");
 		deletePrep.setConsistencyLevel(ConsistencyLevel.QUORUM);
-		updatePrep = session.prepare("UPDATE lock_leases set owner = ? where name = ? IF owner = ?");
+		updatePrep = session.prepare("UPDATE lock_leases USING TTL ? SET owner = ? WHERE name = ? IF owner = ?");
 		updatePrep.setConsistencyLevel(ConsistencyLevel.QUORUM);
 	}
 	


### PR DESCRIPTION
This is necessary to avoid resetting the TTL on a lock record to the table default TTL.

For example, if the table has a default TTL of 60s and the LockFactory is configured with a default TTL of 30s, and you do:

lock.tryLock();
lock.keepAlive();

The TTL on the record will be 60s rather than 30s.

This patch fixes that by using the TTL passed into CassandraLock in the update.